### PR TITLE
update to latest MSAL 4.3.0 and fix acquire token call pattern

### DIFF
--- a/demos/03-add-msgraph/GraphTutorial/GraphTutorial.Android/GraphTutorial.Android.csproj
+++ b/demos/03-add-msgraph/GraphTutorial/GraphTutorial.Android/GraphTutorial.Android.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client">
-      <Version>3.0.8</Version>
+      <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms" Version="4.0.0.425677" />
     <PackageReference Include="Xamarin.Android.Support.Design" Version="28.0.0.1" />

--- a/demos/03-add-msgraph/GraphTutorial/GraphTutorial.iOS/GraphTutorial.iOS.csproj
+++ b/demos/03-add-msgraph/GraphTutorial/GraphTutorial.iOS/GraphTutorial.iOS.csproj
@@ -127,7 +127,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Identity.Client">
-      <Version>3.0.8</Version>
+      <Version>4.3.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms" Version="4.0.0.425677" />
     <PackageReference Include="Xamarin.Essentials" Version="1.1.0" />

--- a/demos/03-add-msgraph/GraphTutorial/GraphTutorial/GraphTutorial.csproj
+++ b/demos/03-add-msgraph/GraphTutorial/GraphTutorial/GraphTutorial.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Graph" Version="1.15.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="3.0.8" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.3.0" />
     <PackageReference Include="Xamarin.Forms" Version="4.0.0.425677" />
     <PackageReference Include="Xamarin.Essentials" Version="1.1.0" />
   </ItemGroup>


### PR DESCRIPTION
Our [recommended call pattern](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/AcquireTokenSilentAsync-using-a-cached-token#recommended-call-pattern-in-public-client-applications-with-msalnet-3x) is to do an AT silent call and then catch the MsalUiRequiredException, and then do the interactive call. just moved a few things around. 

manual testing:
- UW
- Android (I get a token in the cache, but am having issues calling the Graph client, but had the same issue before making the changes)